### PR TITLE
Fixed python and added .gitignore

### DIFF
--- a/bots2/.gitignore
+++ b/bots2/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/bots2/bot.js
+++ b/bots2/bot.js
@@ -1,5 +1,5 @@
-var moment = require('moment');
-const TelegramBot = require('node-telegram-bot-api');
+const moment = require('moment'),
+      TelegramBot = require('node-telegram-bot-api');
 
 const token = '123456789:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 

--- a/bots2/bot.py
+++ b/bots2/bot.py
@@ -77,15 +77,14 @@ def send_message(chat_id, text, disable_web_page_preview=False, reply_to_message
         "text": text,
         "disable_web_page_preview": disable_web_page_preview,
         "reply_to_message_id": reply_to_message_id,
-        "reply_markup": json.dumps(reply_markup),
-        'parse_mode': 'HTML',
+        "reply_markup": reply_markup,
+        "parse_mode": 'HTML',
     })
     run_event(response)
 
 
 def api_request(method, parameters={}, files=None):
-    url = "https://api.telegram.org/bot{token}/{method}" \
-        .format(token=BOT_TOKEN, method=method)
+    url = "https://api.telegram.org/bot{token}/{method}".format(token=BOT_TOKEN, method=method)
 
     http_method = 'get'
 


### PR DESCRIPTION
BTW, Ideally the token should be placed in an external file where the code can read from and that file could be easily ignored in .gitignore in order to avoid neglect of uploading bots private tokens.